### PR TITLE
Initial release after forking from conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 About vc-feedstock
 ==================
 
+The Windows sysroot package.
+
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/vc-feedstock/blob/main/LICENSE.txt)
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -16,48 +16,45 @@ vsver:
  - 17
  - 17
  - 16
-# vc_repack.py checks the expected runtime version (which can be used to find out of course)
+# vc_repack.py checks the expected runtime version.
 runtime_version:
- # the azure/github images only contain the latest minor version per vs-line;
- # if there is a use-case for having older minor versions, they can be added when requested.
  - 14.44.35208
  - 14.44.35208
  - 14.42.34433
  - 14.42.34433
- - 14.29.30139
-# the VS update version.  This is the middle digit in the version
-# reported in the VS help->about UI.  It is perhaps a more readily
-# referenceable number.
+ - 14.29.30133
+# The VS update version. This is the middle digit in the version reported in the VS help->about UI. It is perhaps a
+# more readily referenceable number.
 update_version:
  - 14
  - 14
  - 12
  - 12
  - 11
-# This is the version number reported by cl.exe; if you don't want to or cannot download,
-# candidates can be found with a github code search (adapt minor number as necessary):
+# This is the version number reported by cl.exe; if you don't want to or cannot download, candidates can be found with
+# a GitHub code search (adapt minor number as necessary):
 # https://github.com/search?q=%2F19%5C.40%5C.3%5Cd%5Cd%5Cd%5Cd%2F&type=code
 cl_version:
  - 19.44.35207
  - 19.44.35207
- - 19.42.34433
- - 19.42.34433
- - 19.29.30139
-# This is the uuid in the URL; redirect can be resolved e.g. as follows
-# curl -ILSs https://aka.ms/vs/17/release/vc_redist.x64.exe | grep "Location:"
-# curl -ILSs https://aka.ms/vs/17/release/vc_redist.arm64.exe | grep "Location:"
+ - 19.42.34443
+ - 19.42.34443
+ - 19.29.30159
+# This is the UUID in the URL; redirect can be resolved e.g. as follows
+# curl -ILSs https://aka.ms/vs/16/release/14.29.30139/VC_Redist.x64.exe | grep "Location:"
+# curl -ILSs https://aka.ms/vs/17/release/14.44.35208/VC_Redist.arm64.exe | grep "Location:"
 uuid:
  - 40b59c73-1480-4caf-ab5b-4886f176bf71
  - 40b59c73-1480-4caf-ab5b-4886f176bf71
  - 5319f718-2a84-4aff-86be-8dbdefd92ca1
  - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
- - b929b7fe-5c89-4553-9abe-6324631dcc3a
+ - 7239cdc3-bd73-4f27-9943-22de059a6267
 sha256:
  - 1DB5C25643A3A4E4C99BFD0D0931A702A49C73DADC4B30672687F32188C1724C
  - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
  - C176B30681576B86068F8B55FAE512391EE4217511494B24393C1C9476BC2169
  - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
- - 296F96CD102250636BCD23AB6E6CF70935337B1BBB3507FE8521D8D9CFAA932F
+ - 003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B
 cross_target_platform:
  - win-arm64
  - win-64

--- a/recipe/deactivate.bat
+++ b/recipe/deactivate.bat
@@ -1,0 +1,27 @@
+@@echo off
+
+:: Ensure delayed variable expansion
+setlocal enabledelayedexpansion
+
+:: CMAKE_PREFIX_PATH is set for both the build and runtime environments.
+:: Unlike the build environment, there is a chance that CMAKE_PREFIX_PATH
+:: gets modified after activation, but before deactivation. For this reason
+:: we are removing the conda library path from CMAKE_PREFIX_PATH that we added
+:: instead of restoring the value that was saved in the activation script.
+
+:: Initialize a new variable to store the cleaned path
+set "NEW_CMAKE_PREFIX_PATH="
+
+:: Iterate through each path entry
+for %%I in (%CMAKE_PREFIX_PATH%) do (
+    if /I not "%%I"=="%CONDA_PREFIX%\Library" (
+        if defined NEW_CMAKE_PREFIX_PATH (
+            set "NEW_CMAKE_PREFIX_PATH=!NEW_CMAKE_PREFIX_PATH!;%%I"
+        ) else (
+            set "NEW_CMAKE_PREFIX_PATH=%%I"
+        )
+    )
+)
+
+:: Disable setlocal so changes persist
+endlocal & set "CMAKE_PREFIX_PATH=%NEW_CMAKE_PREFIX_PATH%"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
-# version numbering is explained at https://stackoverflow.com/questions/42730478/version-numbers-for-visual-studio-2017-boost-and-cmake
+# Version numbering is explained at:
+# https://stackoverflow.com/questions/42730478/version-numbers-for-visual-studio-2017-boost-and-cmake
+# https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
 
 # VS2017 is fundamentally compatible with VS2015.  We name our package
 # vs2015_runtime so that it can't be mixed up with the runtime from
@@ -7,18 +9,18 @@
 # with things compiled with VS2015.
 {% set runtime_year = "2015" %}
 
-{% if vsyear is not defined %}
-{% set vsyear = "" %}
-{% set runtime_version = "14.40.33810" %}
-{% set cl_version = "19.40" %}
-{% set vcver = "" %}
+{% if not vsyear %}
+  {% set vsyear = "" %}
+  {% set runtime_version = "14.40.33810" %}
+  {% set cl_version = "19.40" %}
+  {% set vcver = "" %}
 {% endif %}
 
 {% set vc_major = vcver.split(".")[0] %}
-{% set vcvars_ver_maj = cl_version.split(".")[0]|int - 5 %}
-{% set vcvars_ver_min = cl_version.split(".")[1]|int %}
+{% set vcvars_ver_maj = cl_version.split(".")[0] | int - 5 %}
+{% set vcvars_ver_min = cl_version.split(".")[1] | int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 26 %}
+{% set build_num = 9 %}
 
 package:
   name: vs{{ vsyear }}
@@ -44,8 +46,7 @@ outputs:
     version: {{ runtime_version }}
     script: vc_repack.py
     script_interpreter: >-
-      python -m vc_repack --extract --version {{ runtime_version }}
-      --target-platform {{ cross_target_platform }}
+      python -m vc_repack --extract --version {{ runtime_version }} --target-platform {{ cross_target_platform }}
     build:
       skip: True  # [cross_target_platform != target_platform]
       binary_relocation: false
@@ -61,7 +62,9 @@ outputs:
         - p7zip     # [not build_platform.startswith("win")]
       host:
       run:
-        # Need ucrt for windows<10 and when the VC runtime does not bundle it
+        # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
+        # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
+        # vs version comes out that drops support for Windows 10.
         - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10)) and (cross_target_platform == "win-64" or cross_target_platform == "win-32")]
       run_constrained:
         - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}  # [cross_target_platform == "win-64" or cross_target_platform == "win-32"]
@@ -159,12 +162,10 @@ outputs:
   - name: vc
     version: {{ vcver }}
     build:
-      track_features:
-        - vc{{ vc_major }}
       skip: True  # [cross_target_platform != target_platform]
     requirements:
       run:
-        # Set lower bound for runtime (no upper bound).  Upper bound
+        # Set lower bound for runtime (no upper bound). Upper bound
         # is still present, but it's part of the run_exports for the
         # compiler: assume that when vcver's major version changes,
         # MSFT has broken our binary compatibility.
@@ -194,11 +195,11 @@ outputs:
       --activate-vcvars-ver {{ vcvars_ver }}
     build:
       track_features:
-        - vc{{ vc_major }}
+        - vs{{ vsyear }}_{{ cross_target_platform }}_{{ cl_version }}
       run_exports:
         strong:
-          # compatible within major version.  This is MSFT's
-          # incrementing of the UCRT version.  It was 14.0 with
+          # compatible within major version. This is MSFT's
+          # incrementing of the UCRT version. It was 14.0 with
           # VS2015, and 14.1 with VS2017 - if the major version
           # changes, we're assuming that binary compatibility breaks.
           # This has a minimum bound equal to vcver, so building with
@@ -228,11 +229,11 @@ outputs:
     version: "{{ vsyear }}.{{ update_version }}"
     build:
       track_features:
-        - vc{{ vc_major }}
+        - vs_{{ cross_target_platform }}_{{ vsyear }}.{{ update_version }}
       run_exports:
         strong:
-          # compatible within major version.  This is MSFT's
-          # incrementing of the UCRT version.  It was 14.0 with
+          # compatible within major version. This is MSFT's
+          # incrementing of the UCRT version. It was 14.0 with
           # VS2015, and 14.1 with VS2017 - if the major version
           # changes, we're assuming that binary compatibility breaks.
           # This has a minimum bound equal to vcver, so building with

--- a/recipe/vc_repack.py
+++ b/recipe/vc_repack.py
@@ -52,8 +52,7 @@ class Environment:
             raise AttributeError
 
 
-# This class and the subs() function balow are used for substituting
-# variables in the activate.bat template
+# This class and the subs() function below are used for substituting variables in the activate.bat template
 class AtTemplate(string.Template):
     delimiter = "@"
 
@@ -358,19 +357,15 @@ def main():
         else:
             raise RuntimeError(f"Architecture {args.target_platform} not supported")
     elif args.activate:
-        # Populate the activate.bat template, which is used to include
-        # the Visual Studio tools into the conda environment.
-        targetdir = os.path.join(env.prefix, "etc", "conda", "activate.d")
-        os.makedirs(targetdir)
-        with open(os.path.join(env.recipe_dir, "activate.bat"), "r") as r:
-            with open(
-                os.path.join(
-                    targetdir, f"vs{args.activate_year}_compiler_vars.bat"
-                ),
-                "w",
-            ) as w:
-                for line in r:
-                    w.write(subs(line, args))
+        # Populate the activate.bat template, which is used to include the Visual Studio tools into the conda
+        # environment.
+        for script_type in ["activate", "deactivate"]:
+            targetdir = os.path.join(env.prefix, "etc", "conda", f"{script_type}.d")
+            os.makedirs(targetdir)
+            with open(os.path.join(env.recipe_dir, f"{script_type}.bat"), "r") as r:
+                with open(os.path.join(targetdir, f"vs{args.activate_year}_compiler_vars.bat"), "w") as w:
+                    for line in r:
+                        w.write(subs(line, args))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
vc

**Destination channel:** defaults

### Links

- [PKG-5689](https://anaconda.atlassian.net/browse/PKG-5689)
- Relevant dependency PRs:
  - AnacondaRecipes/ucrt-feedstock#2
  - AnacondaRecipes/aggregate#343

### Explanation of changes:

- Updated recipe to use our current compiler and runtime versions

This feedstock replaces the current vs2017, vs2019, and vs2022 feedstocks. It modifies the `vc` meta package to operate as a Windows sysroot which dictates the MSVC compiler version used in a given environment. The traditional `vs2015_runtime` package is deprecated with these changes and is converted into a new meta package, for backwards compatibility, which ensures a compatible `ucrt` and VS runtime version are selected.


[PKG-5689]: https://anaconda.atlassian.net/browse/PKG-5689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ