### PR TITLE
Openmp/add mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: openmp-mutex-rework-4
-
-channels:
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
-staging_channel_upload_target: openmp-mutex-rework-3
+staging_channel_upload_target: openmp-mutex-rework-4
 
 channels:
-  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-3
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
-staging_channel_upload_target: openmp-mutex-rework-2
+staging_channel_upload_target: openmp-mutex-rework-3
 
 channels:
   - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-2
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-  - build
+  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+staging_channel_upload_target: openmp_mutex_testing
+
+channels:
+  - https://staging.continuum.io/pbp/openmp_mutex_testing

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
+staging_channel_upload_target: openmp-mutex-rework-2
+
 channels:
   - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
   - https://staging.continuum.io/pbp/openmp-mutex-rework-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
-staging_channel_upload_target: openmp_mutex_testing
-
 channels:
-  - https://staging.continuum.io/pbp/openmp_mutex_testing
+  - build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,64 +1,64 @@
 vcver:
-# - 14.3
  - 14.3
-# - 14.3
+ - 14.3
+ - 14.3
  - 14.3
  - 14.2
 vsyear:
-# - 2022
  - 2022
-# - 2022
+ - 2022
+ - 2022
  - 2022
  - 2019
 vsver:
-# - 17
  - 17
-# - 17
+ - 17
+ - 17
  - 17
  - 16
 # vc_repack.py checks the expected runtime version.
 runtime_version:
-# - 14.44.35208
  - 14.44.35208
-# - 14.42.34433
+ - 14.44.35208
+ - 14.42.34433
  - 14.42.34433
  - 14.29.30133
 # The VS update version. This is the middle digit in the version reported in the VS help->about UI. It is perhaps a
 # more readily referenceable number.
 update_version:
-# - 14
  - 14
-# - 12
+ - 14
+ - 12
  - 12
  - 11
 # This is the version number reported by cl.exe; if you don't want to or cannot download, candidates can be found with
 # a GitHub code search (adapt minor number as necessary):
 # https://github.com/search?q=%2F19%5C.40%5C.3%5Cd%5Cd%5Cd%5Cd%2F&type=code
 cl_version:
-# - 19.44.35207
  - 19.44.35207
-# - 19.42.34443
+ - 19.44.35207
+ - 19.42.34443
  - 19.42.34443
  - 19.29.30159
 # This is the UUID in the URL; redirect can be resolved e.g. as follows
 # curl -ILSs https://aka.ms/vs/16/release/14.29.30139/VC_Redist.x64.exe | grep "Location:"
 # curl -ILSs https://aka.ms/vs/17/release/14.44.35208/VC_Redist.arm64.exe | grep "Location:"
 uuid:
-# - 40b59c73-1480-4caf-ab5b-4886f176bf71
  - 40b59c73-1480-4caf-ab5b-4886f176bf71
-# - 5319f718-2a84-4aff-86be-8dbdefd92ca1
+ - 40b59c73-1480-4caf-ab5b-4886f176bf71
+ - 5319f718-2a84-4aff-86be-8dbdefd92ca1
  - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
  - 7239cdc3-bd73-4f27-9943-22de059a6267
 sha256:
-# - 1DB5C25643A3A4E4C99BFD0D0931A702A49C73DADC4B30672687F32188C1724C
+ - 1DB5C25643A3A4E4C99BFD0D0931A702A49C73DADC4B30672687F32188C1724C
  - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
-# - C176B30681576B86068F8B55FAE512391EE4217511494B24393C1C9476BC2169
+ - C176B30681576B86068F8B55FAE512391EE4217511494B24393C1C9476BC2169
  - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
  - 003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B
 cross_target_platform:
-# - win-arm64
+ - win-arm64
  - win-64
-# - win-arm64
+ - win-arm64
  - win-64
  - win-64
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,66 +1,66 @@
 vcver:
  - 14.3
  - 14.3
- - 14.3
- - 14.3
- - 14.2
+#  - 14.3
+#  - 14.3
+#  - 14.2
 vsyear:
  - 2022
  - 2022
- - 2022
- - 2022
- - 2019
+#  - 2022
+#  - 2022
+#  - 2019
 vsver:
  - 17
  - 17
- - 17
- - 17
- - 16
+#  - 17
+#  - 17
+#  - 16
 # vc_repack.py checks the expected runtime version.
 runtime_version:
  - 14.44.35208
- - 14.44.35208
+#  - 14.44.35208
  - 14.42.34433
- - 14.42.34433
- - 14.29.30133
+#  - 14.42.34433
+#  - 14.29.30133
 # The VS update version. This is the middle digit in the version reported in the VS help->about UI. It is perhaps a
 # more readily referenceable number.
 update_version:
  - 14
- - 14
+#  - 14
  - 12
- - 12
- - 11
+#  - 12
+#  - 11
 # This is the version number reported by cl.exe; if you don't want to or cannot download, candidates can be found with
 # a GitHub code search (adapt minor number as necessary):
 # https://github.com/search?q=%2F19%5C.40%5C.3%5Cd%5Cd%5Cd%5Cd%2F&type=code
 cl_version:
  - 19.44.35207
- - 19.44.35207
+#  - 19.44.35207
  - 19.42.34443
- - 19.42.34443
- - 19.29.30159
+#  - 19.42.34443
+#  - 19.29.30159
 # This is the UUID in the URL; redirect can be resolved e.g. as follows
 # curl -ILSs https://aka.ms/vs/16/release/14.29.30139/VC_Redist.x64.exe | grep "Location:"
 # curl -ILSs https://aka.ms/vs/17/release/14.44.35208/VC_Redist.arm64.exe | grep "Location:"
 uuid:
  - 40b59c73-1480-4caf-ab5b-4886f176bf71
- - 40b59c73-1480-4caf-ab5b-4886f176bf71
+#  - 40b59c73-1480-4caf-ab5b-4886f176bf71
  - 5319f718-2a84-4aff-86be-8dbdefd92ca1
- - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
- - 7239cdc3-bd73-4f27-9943-22de059a6267
+#  - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
+#  - 7239cdc3-bd73-4f27-9943-22de059a6267
 sha256:
  - 1DB5C25643A3A4E4C99BFD0D0931A702A49C73DADC4B30672687F32188C1724C
- - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
+#  - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
  - C176B30681576B86068F8B55FAE512391EE4217511494B24393C1C9476BC2169
- - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
- - 003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B
+#  - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
+#  - 003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B
 cross_target_platform:
  - win-arm64
- - win-64
+#  - win-64
  - win-arm64
- - win-64
- - win-64
+#  - win-64
+#  - win-64
 
 zip_keys:
  - - vcver

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,65 +1,65 @@
 vcver:
  - 14.3
  - 14.3
-#  - 14.3
-#  - 14.3
+ - 14.3
+ - 14.3
 #  - 14.2
 vsyear:
  - 2022
  - 2022
-#  - 2022
-#  - 2022
+ - 2022
+ - 2022
 #  - 2019
 vsver:
  - 17
  - 17
-#  - 17
-#  - 17
+ - 17
+ - 17
 #  - 16
 # vc_repack.py checks the expected runtime version.
 runtime_version:
  - 14.44.35208
-#  - 14.44.35208
+ - 14.44.35208
  - 14.42.34433
-#  - 14.42.34433
+ - 14.42.34433
 #  - 14.29.30133
 # The VS update version. This is the middle digit in the version reported in the VS help->about UI. It is perhaps a
 # more readily referenceable number.
 update_version:
  - 14
-#  - 14
+ - 14
  - 12
-#  - 12
+ - 12
 #  - 11
 # This is the version number reported by cl.exe; if you don't want to or cannot download, candidates can be found with
 # a GitHub code search (adapt minor number as necessary):
 # https://github.com/search?q=%2F19%5C.40%5C.3%5Cd%5Cd%5Cd%5Cd%2F&type=code
 cl_version:
  - 19.44.35207
-#  - 19.44.35207
+ - 19.44.35207
  - 19.42.34443
-#  - 19.42.34443
+ - 19.42.34443
 #  - 19.29.30159
 # This is the UUID in the URL; redirect can be resolved e.g. as follows
 # curl -ILSs https://aka.ms/vs/16/release/14.29.30139/VC_Redist.x64.exe | grep "Location:"
 # curl -ILSs https://aka.ms/vs/17/release/14.44.35208/VC_Redist.arm64.exe | grep "Location:"
 uuid:
  - 40b59c73-1480-4caf-ab5b-4886f176bf71
-#  - 40b59c73-1480-4caf-ab5b-4886f176bf71
+ - 40b59c73-1480-4caf-ab5b-4886f176bf71
  - 5319f718-2a84-4aff-86be-8dbdefd92ca1
-#  - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
+ - c7dac50a-e3e8-40f6-bbb2-9cc4e3dfcabe
 #  - 7239cdc3-bd73-4f27-9943-22de059a6267
 sha256:
  - 1DB5C25643A3A4E4C99BFD0D0931A702A49C73DADC4B30672687F32188C1724C
-#  - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
+ - D62841375B90782B1829483AC75695CCEF680A8F13E7DE569B992EF33C6CD14A
  - C176B30681576B86068F8B55FAE512391EE4217511494B24393C1C9476BC2169
-#  - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
+ - 1821577409C35B2B9505AC833E246376CC68A8262972100444010B57226F0940
 #  - 003063723B2131DA23F40E2063FB79867BAE275F7B5C099DBD1792E25845872B
 cross_target_platform:
  - win-arm64
-#  - win-64
+ - win-64
  - win-arm64
-#  - win-64
+ - win-64
 #  - win-64
 
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,9 +65,9 @@ outputs:
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.
-        - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10))]
+        - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10)) and (cross_target_platform == "win-64" or cross_target_platform == "win-32")]
       run_constrained:
-        - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}
+        - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}  # [cross_target_platform == "win-64" or cross_target_platform == "win-32"]
     about:
       summary: >-
         MSVC runtimes associated with cl.exe version {{ cl_version }}
@@ -129,9 +129,8 @@ outputs:
             'ucrtbase.dll',
             'vcamp140.dll',
             'vccorlib140.dll',
+            'vcomp140.dll',
             'vcruntime140.dll',
-        ] + (cross_target_platform != "win-arm64") * [
-            'vcomp140.dll',  # OpenMP runtime not included in ARM64 redistributable
         ] + (vsyear | int >= 2019) * [
             'msvcp140_atomic_wait.dll',
             'msvcp140_codecvt_ids.dll',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@
 {% set vcvars_ver_maj = cl_version.split(".")[0] | int - 5 %}
 {% set vcvars_ver_min = cl_version.split(".")[1] | int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 10 %}
+{% set build_num = 11 %}
 
 package:
   name: vs{{ vsyear }}
@@ -41,13 +41,66 @@ build:
   number: {{ build_num }}
   skip: True  # [unix]
   skip: True  # [cross_target_platform != target_platform]
+  script: >-
+    python {{ RECIPE_DIR }}/vc_repack.py --extract --version {{ runtime_version }}
+    --target-platform {{ cross_target_platform }}
+
+requirements:
+  build:
+    - m2-p7zip <10  # [build_platform.startswith("win")]
+    - p7zip     # [not build_platform.startswith("win")]
+    - python
 
 outputs:
+  - name: vcomp{{ vc_major }}
+    version: {{ runtime_version }}
+    script: vc_repack.py
+    script_interpreter: >-
+      python -m vc_repack --install-vcomp
+    build:
+      skip: True  # [cross_target_platform != target_platform or cross_target_platform == "win-arm64"]
+      binary_relocation: false
+      detect_binary_files_with_prefix: false
+      no_link:
+        - Library/bin/*.dll
+      missing_dso_whitelist:
+        - "*.dll"
+        - "*.DLL"
+      run_exports:
+        strong:
+          - _openmp_mutex >=5.0 *_msvc
+          - {{ pin_subpackage("vcomp" ~ vc_major, max_pin=None) }}
+    requirements:
+      build:
+      host:
+      run:
+        - _openmp_mutex >=5.0 *_msvc
+        # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
+        # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
+        # vs version comes out that drops support for Windows 10.
+        - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10)) and (cross_target_platform == "win-64" or cross_target_platform == "win-32")]
+      run_constrained:
+        - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}  # [cross_target_platform == "win-64" or cross_target_platform == "win-32"]
+    about:
+      summary: >-
+        MSVC OpenMP runtime associated with cl.exe version {{ cl_version }}
+        (VS {{ vsyear }} update {{ update_version }})
+      home: https://visualstudio.microsoft.com/downloads/
+      license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+      license_family: Proprietary
+      license_file:
+        - LICENSE.TXT
+        - LICENSE.RTF
+    test:
+      commands:
+        - if not exist %LIBRARY_BIN%\vcomp140.dll exit 1
+        - if not exist %PREFIX%\vcomp140.dll exit 1
+
   - name: vc{{ vc_major }}_runtime
     version: {{ runtime_version }}
     script: vc_repack.py
     script_interpreter: >-
-      python -m vc_repack --extract --version {{ runtime_version }} --target-platform {{ cross_target_platform }}
+      python -m vc_repack --install-runtime
     build:
       skip: True  # [cross_target_platform != target_platform]
       binary_relocation: false
@@ -59,10 +112,10 @@ outputs:
         - "*.DLL"
     requirements:
       build:
-        - m2-p7zip <10  # [build_platform.startswith("win")]
-        - p7zip     # [not build_platform.startswith("win")]
       host:
+        - {{ pin_subpackage("vcomp" ~ vc_major, exact=True) }}  # [cross_target_platform != "win-arm64"]
       run:
+        - {{ pin_subpackage("vcomp" ~ vc_major, exact=True) }}  # [cross_target_platform != "win-arm64"]
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.
@@ -125,7 +178,6 @@ outputs:
             'api-ms-win-crt-time-l1-1-0.dll',
             'api-ms-win-crt-utility-l1-1-0.dll',
             'ucrtbase.dll',
-            'vcomp140.dll',
         ] + [
             # VC runtime DLLs (always present)
             'concrt140.dll',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,13 +68,13 @@ outputs:
         - "*.DLL"
       run_exports:
         strong:
-          - _openmp_mutex *_msvc
+          - _openmp_mutex * *_msvc
           - {{ pin_subpackage("vcomp" ~ vc_major, max_pin=None) }}
     requirements:
       build:
       host:
       run:
-        - _openmp_mutex *_msvc
+        - _openmp_mutex * *_msvc
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,13 +68,13 @@ outputs:
         - "*.DLL"
       run_exports:
         strong:
-          - _openmp_mutex >=6.0 *_msvc
+          - _openmp_mutex *_msvc
           - {{ pin_subpackage("vcomp" ~ vc_major, max_pin=None) }}
     requirements:
       build:
       host:
       run:
-        - _openmp_mutex >=6.0 *_msvc
+        - _openmp_mutex *_msvc
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ source:
 build:
   number: {{ build_num }}
   skip: True  # [unix]
+  skip: True  # [cross_target_platform != target_platform]
 
 outputs:
   - name: vc{{ vc_major }}_runtime

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,8 @@ outputs:
     test:
       commands:
         - dir %PREFIX%\\Library\\bin\\*.dll
-        {% for dllname in [
+        # UCRT DLLs only for win-64/win-32; ARM64 gets UCRT from the OS
+        {% for dllname in (cross_target_platform != "win-arm64") * [
             'api-ms-win-core-console-l1-1-0.dll',
             'api-ms-win-core-datetime-l1-1-0.dll',
             'api-ms-win-core-debug-l1-1-0.dll',
@@ -122,14 +123,16 @@ outputs:
             'api-ms-win-crt-string-l1-1-0.dll',
             'api-ms-win-crt-time-l1-1-0.dll',
             'api-ms-win-crt-utility-l1-1-0.dll',
+            'ucrtbase.dll',
+            'vcomp140.dll',
+        ] + [
+            # VC runtime DLLs (always present)
             'concrt140.dll',
+            'msvcp140.dll',
             'msvcp140_1.dll',
             'msvcp140_2.dll',
-            'msvcp140.dll',
-            'ucrtbase.dll',
             'vcamp140.dll',
             'vccorlib140.dll',
-            'vcomp140.dll',
             'vcruntime140.dll',
         ] + (vsyear | int >= 2019) * [
             'msvcp140_atomic_wait.dll',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,9 +113,7 @@ outputs:
     requirements:
       build:
       host:
-        - {{ pin_subpackage("vcomp" ~ vc_major, exact=True) }}  # [cross_target_platform != "win-arm64"]
       run:
-        - {{ pin_subpackage("vcomp" ~ vc_major, exact=True) }}  # [cross_target_platform != "win-arm64"]
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,9 +65,9 @@ outputs:
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.
-        - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10)) and (cross_target_platform == "win-64" or cross_target_platform == "win-32")]
+        - ucrt >=10.0.20348.0  # [(vsver >=17 or (vsver == 16 and update_version >= 10))]
       run_constrained:
-        - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}  # [cross_target_platform == "win-64" or cross_target_platform == "win-32"]
+        - vs{{ runtime_year }}_runtime {{ runtime_version }}.* *_{{ build_num }}
     about:
       summary: >-
         MSVC runtimes associated with cl.exe version {{ cl_version }}
@@ -129,8 +129,9 @@ outputs:
             'ucrtbase.dll',
             'vcamp140.dll',
             'vccorlib140.dll',
-            'vcomp140.dll',
             'vcruntime140.dll',
+        ] + (cross_target_platform != "win-arm64") * [
+            'vcomp140.dll',  # OpenMP runtime not included in ARM64 redistributable
         ] + (vsyear | int >= 2019) * [
             'msvcp140_atomic_wait.dll',
             'msvcp140_codecvt_ids.dll',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@
 {% set vcvars_ver_maj = cl_version.split(".")[0] | int - 5 %}
 {% set vcvars_ver_min = cl_version.split(".")[1] | int %}
 {% set vcvars_ver = vcvars_ver_maj ~ "." ~ vcvars_ver_min %}
-{% set build_num = 11 %}
+{% set build_num = 12 %}
 
 package:
   name: vs{{ vsyear }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,13 +68,13 @@ outputs:
         - "*.DLL"
       run_exports:
         strong:
-          - _openmp_mutex >=5.0 *_msvc
+          - _openmp_mutex >=6.0 *_msvc
           - {{ pin_subpackage("vcomp" ~ vc_major, max_pin=None) }}
     requirements:
       build:
       host:
       run:
-        - _openmp_mutex >=5.0 *_msvc
+        - _openmp_mutex >=6.0 *_msvc
         # Need ucrt for Windows<10 and when the VC runtime does not bundle it.
         # Can't get vs2022 on Windows<10 so we're good there. Will probably need a new version set here if/when a new
         # vs version comes out that drops support for Windows 10.

--- a/recipe/vc_repack.py
+++ b/recipe/vc_repack.py
@@ -153,13 +153,13 @@ def unpack_cab(cabfile, tmpdir, env):
 
         cwd = os.getcwd()
         # The DLLs needed for executing 7z are in Library\usr\bin,
-        # relative to the prefix directory, so temporarily set the
+        # relative to the build prefix directory, so temporarily set the
         # current directory to contain them.
-        os.chdir(os.path.join(env.prefix, "Library", "usr", "bin"))
+        os.chdir(os.path.join(env.build_prefix, "Library", "usr", "bin"))
 
         # The executable for 7z is not installed on the path either
         cmd = [
-            os.path.join(env.prefix, "Library", "usr", "lib", "p7zip", "7z")
+            os.path.join(env.build_prefix, "Library", "usr", "lib", "p7zip", "7z")
         ]
 
         # And because it's a Cygwin executable, the drive name is
@@ -243,7 +243,7 @@ def decode_manifest(directory):
     )
 
 
-def fix_filename_and_copy(source, dest):
+def fix_filename(source):
     cwd = os.getcwd()
     os.chdir(source)
     # as of VS 17.6, the artefact contains intermediate DLL extensions,
@@ -260,8 +260,31 @@ def fix_filename_and_copy(source, dest):
             os.rename(fname, new_fname)
         else:
             new_fname = fname
-        shutil.copyfile(new_fname, os.path.join(dest, new_fname))
     os.chdir(cwd)
+
+
+def copy_dlls(env, pattern, exclude_pattern=None):
+    cwd = os.getcwd()
+    os.chdir(os.path.join(env.src_dir, "dest"))
+    os.makedirs(env.library_bin, exist_ok=True)
+    os.makedirs(env.prefix, exist_ok=True)
+    excluded = set(glob(exclude_pattern or ""))
+    for fname in glob(pattern):
+        if fname in excluded:
+            continue
+        print(f"Copying DLL: {fname}")
+        shutil.copyfile(fname, os.path.join(env.library_bin, fname))
+        shutil.copyfile(fname, os.path.join(env.prefix, fname))
+    os.chdir(cwd)
+
+
+def copy_vcomp(env):
+    copy_dlls(env, "vcomp*.dll")
+
+
+def copy_runtime(env):
+    copy_dlls(env, "*.dll", exclude_pattern="vcomp*.dll")
+
 
 def unpack_exe(exe_filename, env, version):
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -284,11 +307,14 @@ def unpack_exe(exe_filename, env, version):
 
         with tempfile.TemporaryDirectory() as cabdir2:
             unpack_cab(os.path.join(tmpdir, cabs[1]), cabdir2, env)
-            os.makedirs(env.library_bin)
+            dest = os.path.join(env.src_dir, "dest")
+            if os.path.exists(dest):
+                shutil.rmtree(dest)
+            os.makedirs(dest)
             unpack_cab(
-                os.path.join(cabdir2, payload["cabfile"]), env.library_bin, env
+                os.path.join(cabdir2, payload["cabfile"]), dest, env
             )
-        fix_filename_and_copy(env.library_bin, env.prefix)
+        fix_filename(dest)
 
 
 def main():
@@ -307,7 +333,13 @@ def main():
         default="win-64",
     )
     parser.add_argument(
-        "--extract", help="install files to LIBRARY_BIN", action="store_true"
+        "--extract", help="extract files to SRC_DIR/dest", action="store_true"
+    )
+    parser.add_argument(
+        "--install-runtime", help="install runtimes to LIBRARY_BIN", action="store_true"
+    )
+    parser.add_argument(
+        "--install-vcomp", help="install OpenMP runtimes to LIBRARY_BIN", action="store_true"
     )
     parser.add_argument(
         "--activate", help="install activate.bat", action="store_true"
@@ -333,8 +365,9 @@ def main():
     )
     args = parser.parse_args()
 
-    if not (args.extract or args.activate):
+    if not (args.extract or args.activate or args.install_runtime or args.install_vcomp):
         parser.print_help()
+        print("Need one of --extract, --activate, --install-runtime, --install-vcomp")
         sys.exit(1)
 
     try:
@@ -356,6 +389,10 @@ def main():
                 raise RuntimeError(f"{exe_path} not found")
         else:
             raise RuntimeError(f"Architecture {args.target_platform} not supported")
+    elif args.install_runtime:
+        copy_runtime(env)
+    elif args.install_vcomp:
+        copy_vcomp(env)
     elif args.activate:
         # Populate the activate.bat template, which is used to include the Visual Studio tools into the conda
         # environment.


### PR DESCRIPTION
vc rebuild

**Destination channel:** defaults

### Links

- [PKG-13452](https://anaconda.atlassian.net/browse/PKG-13452) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/_openmp_mutex-feedstock/pull/2

### Explanation of changes:

 Add a new `vcomp14` output containing `vcomp140.dll`.
- Add strong `run_exports` from `vcomp14` for:
  - `_openmp_mutex >=6.0 *_msvc`
  - `vcomp14`
- Update `vc_repack.py` so the redistributable is extracted once, then runtime DLLs and `vcomp*.dll` are installed into separate outputs.
- Remove `vcomp140.dll` from the default `vc14_runtime` output.
- Update the Windows runtime test expectations for the split outputs.


[PKG-13452]: https://anaconda.atlassian.net/browse/PKG-13452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ